### PR TITLE
Make the assertion redirect CPS compliant

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -36,7 +36,7 @@ twig:
 assetic:
     debug:          "%kernel.debug%"
     use_controller: false
-    bundles:        [MopaBootstrapBundle, SurfnetStepupGatewayApiBundle]
+    bundles:        [MopaBootstrapBundle, SurfnetStepupGatewayApiBundle, SurfnetStepupGatewayGatewayBundle]
     #java: /usr/bin/java
     node: "/usr/bin/node"
     node_paths: ["/usr/lib/node_modules"]

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -32,7 +32,6 @@ monolog:
 assetic:
     use_controller: "%use_assetic_controller%"
 
-
 nelmio_security:
     csp:
         img: [ self, 'data:' ]

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/public/css/hiddensubmit.css
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/public/css/hiddensubmit.css
@@ -1,0 +1,3 @@
+.hidden {
+    display: none;
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/public/js/submitonload.js
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/public/js/submitonload.js
@@ -1,0 +1,3 @@
+window.onload = function () {
+    document.forms[0].submit();
+};

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/consumeAssertion.html.twig
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/views/Gateway/consumeAssertion.html.twig
@@ -1,7 +1,15 @@
 {% extends '::base.html.twig' %}
 {% block head_style %}
+    {% stylesheets
+        '@SurfnetStepupGatewayGatewayBundle/Resources/public/css/hiddensubmit.css' %}
+    <link href="{{ asset_url }}" type="text/css" rel="stylesheet" media="screen"/>
+    {% endstylesheets %}
 {% endblock head_style %}
 {% block head_script %}
+    {% javascripts
+    '@SurfnetStepupGatewayGatewayBundle/Resources/public/js/submitonload.js'%}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
 {% endblock head_script %}
 
 {% block body %}
@@ -14,14 +22,9 @@
     {% if relayState|length > 0 %}
         <input type="hidden" name="RelayState" value="{{ relayState|escape }}" />
     {% endif %}
-        <input type="submit" style="display:none;" />
+        <input type="submit" class="hidden" />
     <noscript>
         <input type="submit" value="Submit"/>
     </noscript>
     </form>
-    <script>
-        window.onload = function () {
-            document.forms[0].submit();
-        }
-    </script>
 {% endblock %}


### PR DESCRIPTION
Fixes the issue where the js triggered redirect with a hidden submit button on the gateway would not work.
