### PR TITLE
SSO Session implementation

### DIFF
--- a/build-pre-commit.xml
+++ b/build-pre-commit.xml
@@ -60,13 +60,17 @@
         <loadresource property="changeset.php.absolute.notests">
             <propertyresource name="changeset.php.absolute.newlinesep"/>
             <filterchain>
-                <tokenfilter>
-                    <containsregex pattern="src/(?!Tests).*$"/>
-                </tokenfilter>
-                <deletecharacters chars="\n"/>
+                <linecontains negate="true">
+                    <contains value="Tests"/>
+                </linecontains>
                 <trim/>
                 <ignoreblank/>
                 <tokenfilter delimoutput=","/>
+                <tokenfilter>
+                    <replaceregex pattern="(.*),$"
+                                  flags="s"
+                                  replace="\1"/>
+                </tokenfilter>
             </filterchain>
         </loadresource>
     </target>

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -58,7 +58,6 @@ class GatewayController extends Controller
         /** @var \Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler $stateHandler */
         $stateHandler = $this->get('gateway.proxy.state_handler');
         $stateHandler
-            ->generateSessionIndex($originalRequest->getServiceProvider())
             ->setRequestId($originalRequest->getRequestId())
             ->setRequestServiceProvider($originalRequest->getServiceProvider())
             ->setRelayState($httpRequest->get(AuthnRequest::PARAMETER_RELAY_STATE, ''));

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/Proxy/ProxyStateHandler.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/Proxy/ProxyStateHandler.php
@@ -133,25 +133,6 @@ class ProxyStateHandler
     }
 
     /**
-     * @param string $serviceProvider
-     * @return $this
-     */
-    public function generateSessionIndex($serviceProvider)
-    {
-        $this->set('session_index', md5($serviceProvider . openssl_random_pseudo_bytes(40)));
-
-        return $this;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getSessionIndex()
-    {
-        return $this->get('session_index');
-    }
-
-    /**
      * @param string $assertionAsXmlString
      * @return $this
      */

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
@@ -177,9 +177,6 @@ class ProxyResponseService
     {
         $newAssertion->setAuthnInstant($assertion->getAuthnInstant());
 
-        $sessionNotOnOrAfter = $this->determineSessionNotOnOrAfter($assertion->getSessionNotOnOrAfter());
-        $newAssertion->setSessionNotOnOrAfter($sessionNotOnOrAfter);
-
         // @see https://www.pivotaltracker.com/story/show/79506808
         $newAssertion->setAuthnContextClassRef('https://gw-dev.stepup.coin.surf.net/assurance/LOA1');
 
@@ -222,20 +219,5 @@ class ProxyResponseService
         }
 
         return $time->getTimestamp();
-    }
-
-    /**
-     * @param int $sessionNotOnOrAfter
-     * @return int
-     */
-    private function determineSessionNotOnOrAfter($sessionNotOnOrAfter)
-    {
-        $inEightHours = $this->getTimestamp('PT8H');
-
-        if ($inEightHours < $sessionNotOnOrAfter) {
-            return $inEightHours;
-        }
-
-        return $sessionNotOnOrAfter;
     }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php
@@ -179,7 +179,6 @@ class ProxyResponseService
 
         $sessionNotOnOrAfter = $this->determineSessionNotOnOrAfter($assertion->getSessionNotOnOrAfter());
         $newAssertion->setSessionNotOnOrAfter($sessionNotOnOrAfter);
-        $newAssertion->setSessionIndex($this->proxyStateHandler->getSessionIndex());
 
         // @see https://www.pivotaltracker.com/story/show/79506808
         $newAssertion->setAuthnContextClassRef('https://gw-dev.stepup.coin.surf.net/assurance/LOA1');


### PR DESCRIPTION
We will not keep a (SSO) session on the gateway. Thus:
* Each SP authentication will trigger an authentication request at the IdP (e.g. SURFconext). The IdP may offer SSO.
* Each authentication > LoA 1 will trigger an authentication of the 2nd factor

We will not forward the SSO session information from the IdP to the SSP, or provide session information to the SP. So in the Response from GW to SP:
* No SessionNotOnOrAfter in the AuthnStatement
* No SessionIdentifier in the AuthnStatement

The assertion is to be valid for 5 minutes. 

See https://wiki.surfnet.nl/display/stepup/SAML+2.0+messages for sample SAML messages

---

Checked assertion expiration: https://github.com/SURFnet/Stepup-Gateway/blob/01df5457a82af8c6d8c13b4ee32914331d442b9e/src/Surfnet/StepupGateway/GatewayBundle/Service/ProxyResponseService.php#L94
Ensured LOA>1 = trigger 2nd factor: https://github.com/SURFnet/Stepup-Gateway/blob/01df5457a82af8c6d8c13b4ee32914331d442b9e/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php#L149