### PR TITLE
Break when SP requests invalid LoA

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -72,7 +72,7 @@ class GatewayController extends Controller
             ));
 
             $response = $this->createRequesterFailureResponse();
-            $this->renderSamlResponse('consumeAssertion', $response);
+            return $this->renderSamlResponse('consumeAssertion', $response);
         }
 
         $stateHandler->setRequestAuthnContextClassRef($originalRequest->getAuthenticationContextClassRef());


### PR DESCRIPTION
Because the response was never returned it was possible to request a login with an invalid LoA.