### PR TITLE
Enable entering of Yubikey OTPs in Internet Explorer browsers

### DIFF
--- a/app/Resources/public/less/style.less
+++ b/app/Resources/public/less/style.less
@@ -38,6 +38,7 @@ form[name="gateway_verify_sms_challenge"] {
     }
 }
 
-.btn-hidden {
-    display: none;
+.btn-off-screen {
+    position: absolute;
+    left: 100%;
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifyYubikeyOtpType.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Form/Type/VerifyYubikeyOtpType.php
@@ -40,7 +40,7 @@ class VerifyYubikeyOtpType extends AbstractType
         // This button is the form's default button, so as to prevent the form being submitted as if the cancel button
         // has been pressed.
         $builder->add('submit', 'submit', [
-            'attr'  => ['class' => 'btn btn-hidden'],
+            'attr'  => ['class' => 'btn btn-off-screen'],
         ]);
         $builder->add('cancel', 'submit', [
             'label' => 'gateway.form.verify_yubikey_otp.button.cancel',


### PR DESCRIPTION
This is achieved by placing the Yubikey OTP submit button off-screen
rather than by not displaying it (display:none). The latter solution
makes Internet Explorer browsers pick the cancel button as the first
submit button, canceling the authentication process.

Fixes [Yubikey authentication in IE11 activates the cancel button](https://www.pivotaltracker.com/story/show/103173876).