### PR TITLE
Second Factor Only issues

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/GatewayController.php
@@ -44,7 +44,7 @@ class GatewayController extends Controller
         $redirectBinding = $this->get('surfnet_saml.http.redirect_binding');
 
         try {
-            $originalRequest = $redirectBinding->processUnsignedRequest($httpRequest);
+            $originalRequest = $redirectBinding->processSignedRequest($httpRequest);
         } catch (Exception $e) {
             $logger->critical(sprintf('Could not process Request, error: "%s"', $e->getMessage()));
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/GatewaySamlEntityRepositoryDecorator.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/GatewaySamlEntityRepositoryDecorator.php
@@ -57,6 +57,10 @@ final class GatewaySamlEntityRepositoryDecorator implements SamlEntityRepository
 
         $serviceProvider = $this->repository->getServiceProvider($entityId);
 
+        if (!$serviceProvider instanceof SamlEntity) {
+            return null;
+        }
+
         if (!$serviceProvider->toServiceProvider()->mayUseGateway()) {
             return null;
         }

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Entity/SecondFactorOnlySamlEntityRepositoryDecorator.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Entity/SecondFactorOnlySamlEntityRepositoryDecorator.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupGateway\SecondFactorOnlyBundle\Entity;
 
+use Surfnet\StepupGateway\GatewayBundle\Entity\SamlEntity;
 use Surfnet\StepupGateway\GatewayBundle\Entity\SamlEntityRepository;
 
 final class SecondFactorOnlySamlEntityRepositoryDecorator implements SamlEntityRepository
@@ -40,6 +41,10 @@ final class SecondFactorOnlySamlEntityRepositoryDecorator implements SamlEntityR
     public function getServiceProvider($entityId)
     {
         $serviceProvider = $this->repository->getServiceProvider($entityId);
+
+        if (!$serviceProvider instanceof SamlEntity) {
+            return null;
+        }
 
         if (!$serviceProvider->toServiceProvider()->mayUseSecondFactorOnly()) {
             return null;

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/SecondFactorOnlyNameIdValidationService.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/SecondFactorOnlyNameIdValidationService.php
@@ -43,7 +43,7 @@ final class SecondFactorOnlyNameIdValidationService
     public function validate($spEntityId, $nameId)
     {
         if (!$nameId) {
-            $this->logger->info(
+            $this->logger->notice(
                 'No NameID provided, sending response with status Requester Error'
             );
             return false;
@@ -52,7 +52,7 @@ final class SecondFactorOnlyNameIdValidationService
         $serviceProvider = $this->entityService->getServiceProvider($spEntityId);
 
         if (!$serviceProvider->isAllowedToUseSecondFactorOnlyFor($nameId)) {
-            $this->logger->info(
+            $this->logger->notice(
                 sprintf(
                     'SP "%s" may not use SecondFactorOnly mode for nameid "%s", sending response with status Requester Error',
                     $spEntityId,
@@ -62,7 +62,7 @@ final class SecondFactorOnlyNameIdValidationService
             return false;
         }
 
-        $this->logger->info(
+        $this->logger->notice(
             sprintf(
                 'SP "%s" is allowed to use SecondFactorOnly mode for nameid "%s"',
                 $spEntityId,


### PR DESCRIPTION
* Require Gateway AuthnRequests to be signed.
* Return NULL if Service Provider is not found.	
* Turn SFO nameid validation INFOs into NOTICEs