### PR TITLE
FIx gssf authentication route assembly

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -111,7 +111,7 @@ class SecondFactorController extends Controller
         $this->getStepupService()->clearSmsVerificationState();
 
         $route = 'gateway_verify_second_factor_';
-        if ($secondFactor->requiresGssf()) {
+        if ($secondFactor->isGssf()) {
             $route .= 'gssf';
         }
         else {

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -110,7 +110,14 @@ class SecondFactorController extends Controller
 
         $this->getStepupService()->clearSmsVerificationState();
 
-        $route = 'gateway_verify_second_factor_' . strtolower($secondFactor->secondFactorType);
+        $route = 'gateway_verify_second_factor_';
+        if ($secondFactor->requiresGssf()) {
+            $route .= 'gssf';
+        }
+        else {
+            $route .= strtolower($secondFactor->secondFactorType);
+        }
+
         return $this->redirect($this->generateUrl($route));
     }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -113,8 +113,7 @@ class SecondFactorController extends Controller
         $route = 'gateway_verify_second_factor_';
         if ($secondFactor->isGssf()) {
             $route .= 'gssf';
-        }
-        else {
+        } else {
             $route .= strtolower($secondFactor->secondFactorType);
         }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/EnabledSecondFactorRepository.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/EnabledSecondFactorRepository.php
@@ -33,6 +33,7 @@ final class EnabledSecondFactorRepository implements SecondFactorRepository
      * @var string[]
      */
     private $enabledTypes;
+
     /**
      * @var LoggerInterface
      */

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
@@ -107,7 +107,7 @@ class SecondFactor
     /**
      * @return bool
      */
-    public function requiresGssf()
+    public function isGssf()
     {
         return (new SecondFactorType($this->secondFactorType))->isGssf();
     }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/SecondFactor.php
@@ -103,4 +103,12 @@ class SecondFactor
     {
         return (new SecondFactorType($this->secondFactorType))->getLevel();
     }
+
+    /**
+     * @return bool
+     */
+    public function requiresGssf()
+    {
+        return (new SecondFactorType($this->secondFactorType))->isGssf();
+    }
 }


### PR DESCRIPTION
This bug was introduced in GW 1.4.0 and broke Tiqr and Biometric authentication.

GW 1.4.0 won't be deployed, so no need to backport it.

@rjkip could you review?