### PR TITLE
Do not sign / encrypt cookies by default

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -136,10 +136,6 @@ nelmio_security:
         report_logger_service: monolog.logger.security
         # Content types: default, script, object, style, img, media, frame, font, connect
         default: [ self ]
-    signed_cookie:
-        names: ['*']
-    encrypted_cookie:
-        names: ['*']
 
 services:
     twig.extension.text: # Required by JMSTranslationBundle


### PR DESCRIPTION
The locale cookie should be able to convey which locale has been chosen, obscuring it through the NelmioSecurityBundle would make this impossible

Whenever cookies need to be signed, one could do so explicitly, see: https://github.com/nelmio/NelmioSecurityBundle#signed-cookies