### PR TITLE
Allow dependabot to perform non-major updates for SF packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  # Maintain dependencies for npm
+  # Maintain dependencies for composer
   - package-ecosystem: "composer"
     directories:
       - "/"
@@ -57,6 +57,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "symfony/*"
+        update-types: ["version-update:semver-major"]
     groups:
       php-prod:
         applies-to: version-updates


### PR DESCRIPTION
Prior to this change, Dependabot was not allowed to update Symfony packages at all.

This change allows Dependabot to update symfony packages, except major version bumps.

This is in response to https://github.com/OpenConext/Stepup-Gateway/security/dependabot/83, where dependabot cannot create a fix for a patch version bump that would fix the cve.