### PR TITLE
Fix screenreader-only button

### DIFF
--- a/public/scss/application.scss
+++ b/public/scss/application.scss
@@ -69,8 +69,17 @@ div.page-header {
 }
 
 .btn-off-screen {
-  position: absolute;
-  left: 100%;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 - a 0 height clip, off to the bottom right of the visible 1px box */
+  clip: rect(1px, 1px, 1px, 1px); /*maybe deprecated but we need to support legacy browsers */
+  clip-path: inset(50%); /*modern browsers, clip-path works inwards from each corner*/
+  white-space: nowrap; /* added line to stop words getting smushed together (as they go onto seperate lines and some screen readers do not understand line feeds as a space */
 }
 
 div.middle {


### PR DESCRIPTION
Prior to this change, the screenreader only button expanded the html page beyond its bounds and created a horizontal scrollbar which upon scrolling revealed the submit button.

This change applies a common fix for this issue by using a more robust way of app

See https://github.com/OpenConext/Stepup-Gateway/issues/433#issuecomment-3570745515
See https://stackoverflow.com/a/62109988/7540890