### PR TITLE
Install Node 20 on Scrutinizer build

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,6 +2,7 @@ build:
     image: default-jammy
     environment:
         php: 8.2
+        node: 'v20'
 
     nodes:
         analysis:


### PR DESCRIPTION
The current Scrutenizer builds seem to fail on a insufficiently high node version, so upping it to the version we actually use on our own containers should resolve the issue :crossed_fingers: 