### PR TITLE
Fix premature log entry

### DIFF
--- a/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Controller/SecondFactorController.php
@@ -406,8 +406,8 @@ class SecondFactorController extends ContainerController
             );
         }
 
-        $this->getAuthenticationLogger()->logSecondFactorAuthentication($originalRequestId, $authenticationMode);
         $context->markSecondFactorVerified();
+        $this->getAuthenticationLogger()->logSecondFactorAuthentication($originalRequestId, $authenticationMode);
 
         $logger->info(sprintf(
             'Marked GSSF "%s" as verified, forwarding to Gateway controller to respond',


### PR DESCRIPTION
Prior to this  change, a authentication_result FAILED appeared in the logs, even though the authentication was a success.

This change fixes that by logging after the `markSecondFactorVerified` call, resulting in authentication_result OK.

Fixes https://github.com/OpenConext/Stepup-Gateway/issues/433