### PR TITLE
Fix feature flag incorrectly suppressing middleware service name override

### DIFF
--- a/config/openconext/parameters.yaml.dist
+++ b/config/openconext/parameters.yaml.dist
@@ -190,3 +190,7 @@ parameters:
 
     # The user attribute to use to determine the user's home institution
     fallback_gssp_institution_attribute: 'urn:mace:terena.org:attribute-def:schacHomeOrganization'
+
+    # When enabled, Gateway reads mdui:DisplayName from incoming AuthnRequest extensions and forwards
+    # it in the proxy AuthnRequest to the GSSP. Middleware service_name takes priority if set.
+    enable_service_name_from_saml_authnrequest: false

--- a/src/Surfnet/StepupGateway/GatewayBundle/Configuration/FeatureConfiguration.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Configuration/FeatureConfiguration.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Configuration;
+
+class FeatureConfiguration
+{
+    public function __construct(
+        private readonly bool $enableServiceNameFromSamlAuthnRequest = false
+    ) {
+    }
+
+    public function isServiceNameFromSamlAuthnRequestEnabled(): bool
+    {
+        return $this->enableServiceNameFromSamlAuthnRequest;
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/SamlEntity.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/SamlEntity.php
@@ -132,6 +132,9 @@ class SamlEntity
         if (isset($decodedConfiguration['set_sso_cookie_on_2fa'])) {
             $configuration['setSsoCookieOn2fa'] = $decodedConfiguration['set_sso_cookie_on_2fa'];
         }
+        if (isset($decodedConfiguration['service_name'])) {
+            $configuration['serviceName'] = $decodedConfiguration['service_name'];
+        }
         return new ServiceProvider($configuration);
     }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Entity/ServiceProvider.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Entity/ServiceProvider.php
@@ -150,6 +150,11 @@ class ServiceProvider extends BaseServiceProvider
         );
     }
 
+    public function getServiceName(): ?string
+    {
+        return $this->get('serviceName');
+    }
+
     public function allowSsoOn2fa(): bool
     {
         return $this->get('allowSsoOn2fa');

--- a/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Resources/config/services.yml
@@ -36,6 +36,11 @@ services:
             - "@gateway.proxy.sso.state_handler"
             - "@logger"
 
+    gateway.feature_configuration:
+        class: Surfnet\StepupGateway\GatewayBundle\Configuration\FeatureConfiguration
+        arguments:
+            - "%enable_service_name_from_saml_authnrequest%"
+
     gateway.service.gateway.login:
         class: Surfnet\StepupGateway\GatewayBundle\Service\Gateway\LoginService
         arguments:
@@ -45,6 +50,7 @@ services:
             - "@surfnet_saml.hosted.service_provider"
             - "@surfnet_saml.remote.idp"
             - "@surfnet_saml.http.redirect_binding"
+            - "@gateway.feature_configuration"
 
     gateway.service.gateway.consume_assertion:
         class: Surfnet\StepupGateway\GatewayBundle\Service\Gateway\ConsumeAssertionService

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/DisplayName.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/DisplayName.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Saml;
+
+class DisplayName
+{
+    public function __construct(
+        public readonly string $lang,
+        public readonly string $value
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return ['lang' => $this->lang, 'value' => $this->value];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data['lang'], $data['value']);
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/DisplayName.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/DisplayName.php
@@ -33,6 +33,6 @@ class DisplayName
 
     public static function fromArray(array $data): self
     {
-        return new self($data['lang'], $data['value']);
+        return new self($data['lang'] ?? '', $data['value'] ?? '');
     }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/Proxy/ProxyStateHandler.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/Proxy/ProxyStateHandler.php
@@ -18,6 +18,7 @@
 
 namespace Surfnet\StepupGateway\GatewayBundle\Saml\Proxy;
 
+use Surfnet\StepupGateway\GatewayBundle\Saml\DisplayName;
 use Surfnet\StepupGateway\GatewayBundle\Saml\Exception\RuntimeException;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -205,6 +206,21 @@ class ProxyStateHandler
     public function isSecondFactorFallback(): bool
     {
         return (bool)$this->get('selected_second_factor_fallback');
+    }
+
+    public function setDisplayNamesFromRequest(DisplayName ...$displayNames): self
+    {
+        $this->set('display_names', array_map(fn(DisplayName $d) => $d->toArray(), $displayNames));
+        return $this;
+    }
+
+    /**
+     * @return DisplayName[]
+     */
+    public function getDisplayNamesFromRequest(): array
+    {
+        $raw = $this->get('display_names') ?? [];
+        return array_map(fn(array $d) => DisplayName::fromArray($d), $raw);
     }
 
     public function setGsspUserAttributes(string $subject, string $institution): ProxyStateHandler

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
@@ -28,6 +28,7 @@ use SAML2\XML\saml\Issuer;
 use Surfnet\SamlBundle\Entity\IdentityProvider;
 use Surfnet\StepupGateway\GatewayBundle\Entity\SecondFactor;
 use Surfnet\StepupGateway\GatewayBundle\Entity\ServiceProvider;
+use Surfnet\StepupGateway\GatewayBundle\Saml\DisplayName;
 use Surfnet\StepupGateway\GatewayBundle\Saml\Exception\RuntimeException;
 use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
 use Surfnet\StepupGateway\GatewayBundle\Service\SamlEntityService;
@@ -368,5 +369,30 @@ class ResponseContext
     public function getRequestServiceProvider(): ?string
     {
         return $this->stateHandler->getRequestServiceProvider();
+    }
+
+    /**
+     * @return DisplayName[]
+     */
+    public function getDisplayNamesFromRequest(): array
+    {
+        return $this->stateHandler->getDisplayNamesFromRequest();
+    }
+
+    /**
+     * Resolve display names applying priority: middleware service_name overrides AuthnRequest mdui:DisplayName.
+     *
+     * @return DisplayName[]
+     */
+    public function resolveServiceDisplayNames(): array
+    {
+        $sp = $this->getServiceProvider();
+        if ($sp !== null) {
+            $serviceName = $sp->getServiceName();
+            if ($serviceName !== null && $serviceName !== '') {
+                return [new DisplayName('en', $serviceName)];
+            }
+        }
+        return $this->getDisplayNamesFromRequest();
     }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/ResponseContext.php
@@ -382,9 +382,14 @@ class ResponseContext
     /**
      * Resolve display names applying priority: middleware service_name overrides AuthnRequest mdui:DisplayName.
      *
+     * The middleware service_name override is always considered, regardless of the AuthnRequest
+     * mdui:DisplayName feature flag. Only the AuthnRequest-derived fallback is gated by
+     * $includeAuthnRequestFallback, so callers can suppress it when the feature is disabled without
+     * also losing the (unrelated) middleware override.
+     *
      * @return DisplayName[]
      */
-    public function resolveServiceDisplayNames(): array
+    public function resolveServiceDisplayNames(bool $includeAuthnRequestFallback = true): array
     {
         $sp = $this->getServiceProvider();
         if ($sp !== null) {
@@ -392,6 +397,9 @@ class ResponseContext
             if ($serviceName !== null && $serviceName !== '') {
                 return [new DisplayName('en', $serviceName)];
             }
+        }
+        if (!$includeAuthnRequestFallback) {
+            return [];
         }
         return $this->getDisplayNamesFromRequest();
     }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/UiInfoExtensionHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/UiInfoExtensionHelper.php
@@ -30,19 +30,23 @@ class UiInfoExtensionHelper
     private const MDUI_NAMESPACE = 'urn:oasis:names:tc:SAML:metadata:ui';
     private const MDUI_PREFIX = 'mdui';
 
+    private const MAX_DISPLAY_NAMES = 10;
+    private const MAX_LANG_LENGTH = 35;
+    private const MAX_VALUE_LENGTH = 1024;
+
     /**
-     * Parse UIInfo display names from an AuthnRequest and store them in state if present.
+     * Parse UIInfo display names from an AuthnRequest and store them in state.
+     *
+     * Always overwrites the stored display names, so a request without UIInfo
+     * clears any display names left over from a previous request in the same session.
      */
     public static function parseAndStore(ReceivedAuthnRequest $request, ProxyStateHandler $stateHandler): void
     {
         $chunks = $request->getExtensions()->getChunks();
-        if (!isset($chunks['UIInfo'])) {
-            return;
-        }
-        $displayNames = self::parseDisplayNamesFromChunk($chunks['UIInfo']);
-        if (!empty($displayNames)) {
-            $stateHandler->setDisplayNamesFromRequest(...$displayNames);
-        }
+        $displayNames = isset($chunks['UIInfo'])
+            ? self::parseDisplayNamesFromChunk($chunks['UIInfo'])
+            : [];
+        $stateHandler->setDisplayNamesFromRequest(...$displayNames);
     }
 
     /**
@@ -64,8 +68,15 @@ class UiInfoExtensionHelper
             }
             $lang = $child->getAttribute('xml:lang');
             $value = $child->textContent;
-            if ($lang !== '' && $value !== '') {
-                $displayNames[] = new DisplayName($lang, $value);
+            if ($lang === '' || $value === ''
+                || strlen($lang) > self::MAX_LANG_LENGTH
+                || strlen($value) > self::MAX_VALUE_LENGTH
+            ) {
+                continue;
+            }
+            $displayNames[] = new DisplayName($lang, $value);
+            if (count($displayNames) >= self::MAX_DISPLAY_NAMES) {
+                break;
             }
         }
 

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/UiInfoExtensionHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/UiInfoExtensionHelper.php
@@ -68,10 +68,7 @@ class UiInfoExtensionHelper
             }
             $lang = $child->getAttribute('xml:lang');
             $value = $child->textContent;
-            if ($lang === '' || $value === ''
-                || strlen($lang) > self::MAX_LANG_LENGTH
-                || strlen($value) > self::MAX_VALUE_LENGTH
-            ) {
+            if (!self::isAcceptableDisplayName($lang, $value)) {
                 continue;
             }
             $displayNames[] = new DisplayName($lang, $value);
@@ -81,6 +78,13 @@ class UiInfoExtensionHelper
         }
 
         return $displayNames;
+    }
+
+    private static function isAcceptableDisplayName(string $lang, string $value): bool
+    {
+        return $lang !== '' && $value !== ''
+            && strlen($lang) <= self::MAX_LANG_LENGTH
+            && strlen($value) <= self::MAX_VALUE_LENGTH;
     }
 
     /**

--- a/src/Surfnet/StepupGateway/GatewayBundle/Saml/UiInfoExtensionHelper.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Saml/UiInfoExtensionHelper.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Saml;
+
+use DOMDocument;
+use DOMElement;
+use Surfnet\SamlBundle\SAML2\Extensions\Chunk;
+use Surfnet\SamlBundle\SAML2\Extensions\Extensions;
+use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
+use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
+
+class UiInfoExtensionHelper
+{
+    private const MDUI_NAMESPACE = 'urn:oasis:names:tc:SAML:metadata:ui';
+    private const MDUI_PREFIX = 'mdui';
+
+    /**
+     * Parse UIInfo display names from an AuthnRequest and store them in state if present.
+     */
+    public static function parseAndStore(ReceivedAuthnRequest $request, ProxyStateHandler $stateHandler): void
+    {
+        $chunks = $request->getExtensions()->getChunks();
+        if (!isset($chunks['UIInfo'])) {
+            return;
+        }
+        $displayNames = self::parseDisplayNamesFromChunk($chunks['UIInfo']);
+        if (!empty($displayNames)) {
+            $stateHandler->setDisplayNamesFromRequest(...$displayNames);
+        }
+    }
+
+    /**
+     * Extract DisplayName entries from a UIInfo Chunk.
+     *
+     * @return DisplayName[]
+     */
+    public static function parseDisplayNamesFromChunk(Chunk $chunk): array
+    {
+        $displayNames = [];
+        $uiInfoElement = $chunk->getValue();
+
+        foreach ($uiInfoElement->childNodes as $child) {
+            if (!($child instanceof DOMElement)) {
+                continue;
+            }
+            if ($child->localName !== 'DisplayName' || $child->namespaceURI !== self::MDUI_NAMESPACE) {
+                continue;
+            }
+            $lang = $child->getAttribute('xml:lang');
+            $value = $child->textContent;
+            if ($lang !== '' && $value !== '') {
+                $displayNames[] = new DisplayName($lang, $value);
+            }
+        }
+
+        return $displayNames;
+    }
+
+    /**
+     * Build an Extensions object containing a mdui:UIInfo with the given display names.
+     *
+     * @param DisplayName[] $displayNames
+     */
+    public static function buildExtensionsWithUiInfo(array $displayNames): Extensions
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $uiInfo = $doc->createElementNS(self::MDUI_NAMESPACE, self::MDUI_PREFIX . ':UIInfo');
+        $doc->appendChild($uiInfo);
+
+        foreach ($displayNames as $entry) {
+            $displayName = $doc->createElementNS(self::MDUI_NAMESPACE, self::MDUI_PREFIX . ':DisplayName');
+            $displayName->setAttribute('xml:lang', $entry->lang);
+            $displayName->textContent = $entry->value;
+            $uiInfo->appendChild($displayName);
+        }
+
+        $chunk = new Chunk('UIInfo', self::MDUI_NAMESPACE, $doc->documentElement);
+        $extensions = new Extensions();
+        $extensions->addChunk($chunk);
+
+        return $extensions;
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Service/Gateway/LoginService.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Service/Gateway/LoginService.php
@@ -25,8 +25,10 @@ use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
 use Surfnet\StepupBundle\Service\LoaResolutionService;
+use Surfnet\StepupGateway\GatewayBundle\Configuration\FeatureConfiguration;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RequesterFailureException;
 use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
+use Surfnet\StepupGateway\GatewayBundle\Saml\UiInfoExtensionHelper;
 use Symfony\Component\HttpFoundation\Request;
 
 class LoginService
@@ -66,7 +68,8 @@ class LoginService
         LoaResolutionService $loaResolutionService,
         ServiceProvider $hostedServiceProvider,
         IdentityProvider $remoteIdp,
-        RedirectBinding $redirectBinding
+        RedirectBinding $redirectBinding,
+        private readonly FeatureConfiguration $featureConfiguration = new FeatureConfiguration()
     ) {
         $this->samlLogger = $samlLogger;
         $this->stateHandler = $stateHandler;
@@ -120,6 +123,10 @@ class LoginService
             ->setResponseContextServiceId(static::RESPONSE_CONTEXT_SERVICE_ID);
 
         $this->stateHandler->markAuthenticationModeForRequest($originalRequestId, 'sso');
+
+        if ($this->featureConfiguration->isServiceNameFromSamlAuthnRequestEnabled()) {
+            UiInfoExtensionHelper::parseAndStore($originalRequest, $this->stateHandler);
+        }
 
         // check if the requested Loa is supported
         $requiredLoa = $originalRequest->getAuthenticationContextClassRef();

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/Proxy/ProxyStateHandlerDisplayNameTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/Proxy/ProxyStateHandlerDisplayNameTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Tests\Saml\Proxy;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Surfnet\StepupGateway\GatewayBundle\Saml\DisplayName;
+use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class ProxyStateHandlerDisplayNameTest extends TestCase
+{
+    private ProxyStateHandler $stateHandler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $storage = new MockArraySessionStorage();
+        $session = new Session($storage);
+        $requestStack = Mockery::mock(RequestStack::class);
+        $requestStack->shouldReceive('getSession')->andReturn($session);
+
+        $this->stateHandler = new ProxyStateHandler($requestStack, 'surfnet/gateway/request');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_roundtrips_display_names_through_session(): void
+    {
+        $input = [
+            new DisplayName('en', 'My Service'),
+            new DisplayName('nl', 'Mijn Dienst'),
+        ];
+
+        $this->stateHandler->setDisplayNamesFromRequest(...$input);
+        $result = $this->stateHandler->getDisplayNamesFromRequest();
+
+        $this->assertCount(2, $result);
+        $this->assertEquals(new DisplayName('en', 'My Service'), $result[0]);
+        $this->assertEquals(new DisplayName('nl', 'Mijn Dienst'), $result[1]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_empty_array_when_no_display_names_stored(): void
+    {
+        $result = $this->stateHandler->getDisplayNamesFromRequest();
+
+        $this->assertSame([], $result);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_stores_as_plain_arrays_in_session_for_safe_serialization(): void
+    {
+        $this->stateHandler->setDisplayNamesFromRequest(new DisplayName('en', 'Test'));
+
+        // Verify that what is actually in the session is a plain array, not objects,
+        // so that serialization across deploys is safe.
+        $session = $this->stateHandler->getDisplayNamesFromRequest();
+        $this->assertContainsOnlyInstancesOf(DisplayName::class, $session);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_overwrites_previously_stored_display_names(): void
+    {
+        $this->stateHandler->setDisplayNamesFromRequest(new DisplayName('en', 'First'));
+        $this->stateHandler->setDisplayNamesFromRequest(new DisplayName('en', 'Second'));
+
+        $result = $this->stateHandler->getDisplayNamesFromRequest();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Second', $result[0]->value);
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/ResponseContextResolveDisplayNamesTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/ResponseContextResolveDisplayNamesTest.php
@@ -159,4 +159,55 @@ class ResponseContextResolveDisplayNamesTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertSame('Fallback Name', $result[0]->value);
     }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_middleware_service_name_even_when_authn_request_fallback_is_disabled(): void
+    {
+        $sp = new GatewayServiceProvider([
+            'entityId' => 'sp.example.com',
+            'assertionConsumerUrl' => 'sp.example.com/acs',
+            'privateKeys' => [],
+            'serviceName' => 'Middleware Service Name',
+        ]);
+
+        $this->stateHandler->setRequestServiceProvider('sp.example.com');
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('sp.example.com')
+            ->andReturn($sp);
+
+        $this->stateHandler->setDisplayNamesFromRequest(
+            new DisplayName('en', 'AuthnRequest Name'),
+            new DisplayName('nl', 'AuthnRequest Naam')
+        );
+
+        $result = $this->responseContext->resolveServiceDisplayNames(includeAuthnRequestFallback: false);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('en', $result[0]->lang);
+        $this->assertSame('Middleware Service Name', $result[0]->value);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_empty_when_authn_request_fallback_is_disabled_and_sp_has_no_service_name(): void
+    {
+        $sp = new GatewayServiceProvider([
+            'entityId' => 'sp.example.com',
+            'assertionConsumerUrl' => 'sp.example.com/acs',
+            'privateKeys' => [],
+        ]);
+
+        $this->stateHandler->setRequestServiceProvider('sp.example.com');
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('sp.example.com')
+            ->andReturn($sp);
+
+        $this->stateHandler->setDisplayNamesFromRequest(
+            new DisplayName('en', 'AuthnRequest Name'),
+            new DisplayName('nl', 'AuthnRequest Naam')
+        );
+
+        $result = $this->responseContext->resolveServiceDisplayNames(includeAuthnRequestFallback: false);
+
+        $this->assertSame([], $result);
+    }
 }

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/ResponseContextResolveDisplayNamesTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/ResponseContextResolveDisplayNamesTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Tests\Saml;
+
+use DateTime;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use Surfnet\SamlBundle\Entity\IdentityProvider;
+use Surfnet\StepupGateway\GatewayBundle\Entity\ServiceProvider as GatewayServiceProvider;
+use Surfnet\StepupGateway\GatewayBundle\Saml\DisplayName;
+use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
+use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
+use Surfnet\StepupGateway\GatewayBundle\Service\SamlEntityService;
+use Surfnet\StepupGateway\GatewayBundle\Tests\Logger\Logger;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class ResponseContextResolveDisplayNamesTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private ProxyStateHandler $stateHandler;
+    private SamlEntityService $samlEntityService;
+    private ResponseContext $responseContext;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $storage = new MockArraySessionStorage();
+        $session = new Session($storage);
+        $requestStack = Mockery::mock(RequestStack::class);
+        $requestStack->shouldReceive('getSession')->andReturn($session);
+
+        $this->stateHandler = new ProxyStateHandler($requestStack, 'surfnet/gateway/request');
+        $this->samlEntityService = Mockery::mock(SamlEntityService::class);
+
+        $idp = Mockery::mock(IdentityProvider::class);
+        $idp->shouldReceive('getEntityId')->andReturn('idp.example.com');
+
+        $this->responseContext = new ResponseContext(
+            $idp,
+            $this->samlEntityService,
+            $this->stateHandler,
+            new Logger(),
+            new DateTime('@1534496300')
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_middleware_service_name_when_sp_has_service_name_set(): void
+    {
+        $sp = new GatewayServiceProvider([
+            'entityId' => 'sp.example.com',
+            'assertionConsumerUrl' => 'sp.example.com/acs',
+            'privateKeys' => [],
+            'serviceName' => 'Middleware Service Name',
+        ]);
+
+        $this->stateHandler->setRequestServiceProvider('sp.example.com');
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('sp.example.com')
+            ->andReturn($sp);
+
+        $this->stateHandler->setDisplayNamesFromRequest(
+            new DisplayName('en', 'AuthnRequest Name'),
+            new DisplayName('nl', 'AuthnRequest Naam')
+        );
+
+        $result = $this->responseContext->resolveServiceDisplayNames();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('en', $result[0]->lang);
+        $this->assertSame('Middleware Service Name', $result[0]->value);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_falls_back_to_authn_request_display_names_when_sp_has_no_service_name(): void
+    {
+        $sp = new GatewayServiceProvider([
+            'entityId' => 'sp.example.com',
+            'assertionConsumerUrl' => 'sp.example.com/acs',
+            'privateKeys' => [],
+        ]);
+
+        $this->stateHandler->setRequestServiceProvider('sp.example.com');
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('sp.example.com')
+            ->andReturn($sp);
+
+        $this->stateHandler->setDisplayNamesFromRequest(
+            new DisplayName('en', 'AuthnRequest Name'),
+            new DisplayName('nl', 'AuthnRequest Naam')
+        );
+
+        $result = $this->responseContext->resolveServiceDisplayNames();
+
+        $this->assertCount(2, $result);
+        $this->assertEquals(new DisplayName('en', 'AuthnRequest Name'), $result[0]);
+        $this->assertEquals(new DisplayName('nl', 'AuthnRequest Naam'), $result[1]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_empty_when_sp_has_no_service_name_and_no_display_names_stored(): void
+    {
+        $sp = new GatewayServiceProvider([
+            'entityId' => 'sp.example.com',
+            'assertionConsumerUrl' => 'sp.example.com/acs',
+            'privateKeys' => [],
+        ]);
+
+        $this->stateHandler->setRequestServiceProvider('sp.example.com');
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('sp.example.com')
+            ->andReturn($sp);
+
+        $result = $this->responseContext->resolveServiceDisplayNames();
+
+        $this->assertSame([], $result);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_ignores_empty_string_service_name_and_falls_back_to_authn_request(): void
+    {
+        $sp = new GatewayServiceProvider([
+            'entityId' => 'sp.example.com',
+            'assertionConsumerUrl' => 'sp.example.com/acs',
+            'privateKeys' => [],
+            'serviceName' => '',
+        ]);
+
+        $this->stateHandler->setRequestServiceProvider('sp.example.com');
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('sp.example.com')
+            ->andReturn($sp);
+
+        $this->stateHandler->setDisplayNamesFromRequest(new DisplayName('en', 'Fallback Name'));
+
+        $result = $this->responseContext->resolveServiceDisplayNames();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Fallback Name', $result[0]->value);
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/UiInfoExtensionHelperTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/UiInfoExtensionHelperTest.php
@@ -176,6 +176,66 @@ class UiInfoExtensionHelperTest extends GatewaySamlTestCase
         $this->assertSame([], $stateHandler->getDisplayNamesFromRequest());
     }
 
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function parse_and_store_clears_display_names_from_a_previous_request(): void
+    {
+        $stateHandler = $this->buildStateHandler();
+        $stateHandler->setDisplayNamesFromRequest(new DisplayName('en', 'Previous Service'));
+
+        $request = \Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest::from('<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_test3" Version="2.0" IssueInstant="2017-04-18T16:35:32Z" Destination="https://example.com" AssertionConsumerServiceURL="https://example.com/acs" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"><saml:Issuer>https://example.com</saml:Issuer></samlp:AuthnRequest>');
+
+        UiInfoExtensionHelper::parseAndStore($request, $stateHandler);
+
+        $this->assertSame([], $stateHandler->getDisplayNamesFromRequest());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_limits_the_number_of_parsed_display_names(): void
+    {
+        $langToValue = [];
+        for ($i = 0; $i < 25; $i++) {
+            $langToValue['x-l' . $i] = 'Service ' . $i;
+        }
+        $chunk = $this->buildUiInfoChunk($langToValue);
+
+        $displayNames = UiInfoExtensionHelper::parseDisplayNamesFromChunk($chunk);
+
+        $this->assertCount(10, $displayNames);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_skips_display_names_exceeding_length_limits(): void
+    {
+        $chunk = $this->buildUiInfoChunk([
+            'en' => str_repeat('a', 1025),
+            str_repeat('l', 36) => 'Too long lang',
+            'nl' => 'Acceptable Service',
+        ]);
+
+        $displayNames = UiInfoExtensionHelper::parseDisplayNamesFromChunk($chunk);
+
+        $this->assertCount(1, $displayNames);
+        $this->assertSame('nl', $displayNames[0]->lang);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function display_name_from_array_tolerates_missing_keys(): void
+    {
+        $displayName = DisplayName::fromArray([]);
+
+        $this->assertSame('', $displayName->lang);
+        $this->assertSame('', $displayName->value);
+    }
+
+    private function buildStateHandler(): \Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler
+    {
+        $storage = new \Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage();
+        $session = new \Symfony\Component\HttpFoundation\Session\Session($storage);
+        $requestStack = \Mockery::mock(\Symfony\Component\HttpFoundation\RequestStack::class);
+        $requestStack->shouldReceive('getSession')->andReturn($session);
+        return new \Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler($requestStack, 'surfnet/gateway/request');
+    }
+
     private function buildUiInfoChunk(array $langToValue): Chunk
     {
         $doc = new DOMDocument('1.0', 'UTF-8');

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/UiInfoExtensionHelperTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Saml/UiInfoExtensionHelperTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupGateway\GatewayBundle\Tests\Saml;
+
+use DOMDocument;
+use Mockery;
+use Surfnet\SamlBundle\SAML2\Extensions\Chunk;
+use Surfnet\StepupGateway\GatewayBundle\Saml\DisplayName;
+use Surfnet\StepupGateway\GatewayBundle\Saml\UiInfoExtensionHelper;
+use Surfnet\StepupGateway\GatewayBundle\Tests\TestCase\GatewaySamlTestCase;
+
+class UiInfoExtensionHelperTest extends GatewaySamlTestCase
+{
+    private const MDUI_NAMESPACE = 'urn:oasis:names:tc:SAML:metadata:ui';
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_parses_display_names_from_a_ui_info_chunk(): void
+    {
+        $chunk = $this->buildUiInfoChunk([
+            'en' => 'Online learning environment',
+            'nl' => 'Elektronische leeromgeving',
+        ]);
+
+        $displayNames = UiInfoExtensionHelper::parseDisplayNamesFromChunk($chunk);
+
+        $this->assertCount(2, $displayNames);
+        $this->assertContainsEquals(new DisplayName('en', 'Online learning environment'), $displayNames);
+        $this->assertContainsEquals(new DisplayName('nl', 'Elektronische leeromgeving'), $displayNames);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_empty_array_when_ui_info_has_no_display_names(): void
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $uiInfo = $doc->createElementNS(self::MDUI_NAMESPACE, 'mdui:UIInfo');
+        $doc->appendChild($uiInfo);
+        $chunk = new Chunk('UIInfo', self::MDUI_NAMESPACE, $doc->documentElement);
+
+        $displayNames = UiInfoExtensionHelper::parseDisplayNamesFromChunk($chunk);
+
+        $this->assertSame([], $displayNames);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_builds_extensions_with_ui_info_from_display_names(): void
+    {
+        $input = [
+            new DisplayName('en', 'My Service'),
+            new DisplayName('nl', 'Mijn Dienst'),
+        ];
+
+        $extensions = UiInfoExtensionHelper::buildExtensionsWithUiInfo($input);
+
+        $chunks = $extensions->getChunks();
+        $this->assertArrayHasKey('UIInfo', $chunks);
+
+        $uiInfoElement = $chunks['UIInfo']->getValue();
+        $this->assertSame('UIInfo', $uiInfoElement->localName);
+        $this->assertSame(self::MDUI_NAMESPACE, $uiInfoElement->namespaceURI);
+
+        $displayNameNodes = $uiInfoElement->childNodes;
+        $this->assertSame(2, $displayNameNodes->length);
+
+        $first = $displayNameNodes->item(0);
+        $this->assertSame('en', $first->getAttribute('xml:lang'));
+        $this->assertSame('My Service', $first->textContent);
+
+        $second = $displayNameNodes->item(1);
+        $this->assertSame('nl', $second->getAttribute('xml:lang'));
+        $this->assertSame('Mijn Dienst', $second->textContent);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_roundtrips_display_names(): void
+    {
+        $input = [
+            new DisplayName('en', 'Round Trip Service'),
+        ];
+
+        $extensions = UiInfoExtensionHelper::buildExtensionsWithUiInfo($input);
+        $chunks = $extensions->getChunks();
+        $chunk = $chunks['UIInfo'];
+
+        $parsed = UiInfoExtensionHelper::parseDisplayNamesFromChunk($chunk);
+
+        $this->assertEquals($input, $parsed);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_skips_display_names_with_empty_lang_attribute(): void
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $uiInfo = $doc->createElementNS(self::MDUI_NAMESPACE, 'mdui:UIInfo');
+        $doc->appendChild($uiInfo);
+
+        $blank = $doc->createElementNS(self::MDUI_NAMESPACE, 'mdui:DisplayName');
+        $blank->setAttribute('xml:lang', '');
+        $blank->textContent = 'Some Service';
+        $uiInfo->appendChild($blank);
+
+        $valid = $doc->createElementNS(self::MDUI_NAMESPACE, 'mdui:DisplayName');
+        $valid->setAttribute('xml:lang', 'en');
+        $valid->textContent = 'Some Service';
+        $uiInfo->appendChild($valid);
+
+        $chunk = new Chunk('UIInfo', self::MDUI_NAMESPACE, $doc->documentElement);
+        $result = UiInfoExtensionHelper::parseDisplayNamesFromChunk($chunk);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('en', $result[0]->lang);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_skips_elements_from_other_namespaces(): void
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $uiInfo = $doc->createElementNS(self::MDUI_NAMESPACE, 'mdui:UIInfo');
+        $doc->appendChild($uiInfo);
+
+        $foreign = $doc->createElementNS('urn:some:other:namespace', 'other:DisplayName');
+        $foreign->setAttribute('xml:lang', 'en');
+        $foreign->textContent = 'Should be ignored';
+        $uiInfo->appendChild($foreign);
+
+        $chunk = new Chunk('UIInfo', self::MDUI_NAMESPACE, $doc->documentElement);
+        $result = UiInfoExtensionHelper::parseDisplayNamesFromChunk($chunk);
+
+        $this->assertSame([], $result);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function parse_and_store_does_nothing_when_no_ui_info_chunk_present(): void
+    {
+        $storage = new \Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage();
+        $session = new \Symfony\Component\HttpFoundation\Session\Session($storage);
+        $requestStack = \Mockery::mock(\Symfony\Component\HttpFoundation\RequestStack::class);
+        $requestStack->shouldReceive('getSession')->andReturn($session);
+        $stateHandler = new \Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler($requestStack, 'surfnet/gateway/request');
+
+        $request = \Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest::from('<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_test" Version="2.0" IssueInstant="2017-04-18T16:35:32Z" Destination="https://example.com" AssertionConsumerServiceURL="https://example.com/acs" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"><saml:Issuer>https://example.com</saml:Issuer></samlp:AuthnRequest>');
+
+        UiInfoExtensionHelper::parseAndStore($request, $stateHandler);
+
+        $this->assertSame([], $stateHandler->getDisplayNamesFromRequest());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function parse_and_store_does_nothing_when_ui_info_has_no_valid_display_names(): void
+    {
+        $storage = new \Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage();
+        $session = new \Symfony\Component\HttpFoundation\Session\Session($storage);
+        $requestStack = \Mockery::mock(\Symfony\Component\HttpFoundation\RequestStack::class);
+        $requestStack->shouldReceive('getSession')->andReturn($session);
+        $stateHandler = new \Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler($requestStack, 'surfnet/gateway/request');
+
+        $request = \Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest::from('<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" ID="_test2" Version="2.0" IssueInstant="2017-04-18T16:35:32Z" Destination="https://example.com" AssertionConsumerServiceURL="https://example.com/acs" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"><saml:Issuer>https://example.com</saml:Issuer><samlp:Extensions><mdui:UIInfo><mdui:DisplayName xml:lang="">Empty lang</mdui:DisplayName></mdui:UIInfo></samlp:Extensions></samlp:AuthnRequest>');
+
+        UiInfoExtensionHelper::parseAndStore($request, $stateHandler);
+
+        $this->assertSame([], $stateHandler->getDisplayNamesFromRequest());
+    }
+
+    private function buildUiInfoChunk(array $langToValue): Chunk
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $uiInfo = $doc->createElementNS(self::MDUI_NAMESPACE, 'mdui:UIInfo');
+        $doc->appendChild($uiInfo);
+
+        foreach ($langToValue as $lang => $value) {
+            $displayName = $doc->createElementNS(self::MDUI_NAMESPACE, 'mdui:DisplayName');
+            $displayName->setAttribute('xml:lang', $lang);
+            $displayName->textContent = $value;
+            $uiInfo->appendChild($displayName);
+        }
+
+        return new Chunk('UIInfo', self::MDUI_NAMESPACE, $doc->documentElement);
+    }
+}

--- a/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/Gateway/LoginServiceTest.php
+++ b/src/Surfnet/StepupGateway/GatewayBundle/Tests/Service/Gateway/LoginServiceTest.php
@@ -29,6 +29,7 @@ use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
 use Surfnet\StepupBundle\Service\LoaResolutionService;
 use Surfnet\StepupBundle\Value\Loa;
+use Surfnet\StepupGateway\GatewayBundle\Configuration\FeatureConfiguration;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RequesterFailureException;
 use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
@@ -167,6 +168,90 @@ final class LoginServiceTest extends GatewaySamlTestCase
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
+    public function it_stores_display_names_from_ui_info_when_flag_is_enabled(): void
+    {
+        $this->initGatewayService(
+            ['ssoUrl' => 'idp.nl/sso-url', 'entityId' => 'idp.nl/entity-id', 'privateKeys' => [$this->mockConfigurationPrivateKey('default', 'key.key')], 'certificateFile' => $this->getKeyPath('/key.crt')],
+            ['assertionConsumerUrl' => 'sp.nl/consumer-url', 'entityId' => 'sp.nl/consumer-url', 'privateKeys' => [$this->mockConfigurationPrivateKey('default', 'key2.key')]],
+            [[1, 'http://stepup.example.com/assurance/loa1'], [2, 'http://stepup.example.com/assurance/loa2'], [3, 'http://stepup.example.com/assurance/loa3']],
+            new \DateTime('@' . static::MOCK_TIMESTAMP),
+            true
+        );
+
+        $httpRequest = new Request([AuthnRequest::PARAMETER_RELAY_STATE => 'relay_state']);
+
+        $originalRequest = '<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    ID="_123456789012345678901234567890123456789012"
+    Version="2.0"
+    IssueInstant="2014-10-22T11:06:59Z"
+    Destination="https://gateway.org/sso"
+    AssertionConsumerServiceURL="https://sp.com/acs"
+    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+  <saml:Issuer>https://sp.com/metadata</saml:Issuer>
+  <samlp:Extensions>
+    <mdui:UIInfo>
+      <mdui:DisplayName xml:lang="en">Online learning</mdui:DisplayName>
+      <mdui:DisplayName xml:lang="nl">Online leren</mdui:DisplayName>
+    </mdui:UIInfo>
+  </samlp:Extensions>
+  <samlp:RequestedAuthnContext>
+    <saml:AuthnContextClassRef>http://stepup.example.com/assurance/loa2</saml:AuthnContextClassRef>
+  </samlp:RequestedAuthnContext>
+</samlp:AuthnRequest>';
+
+        $this->mockSessionData('_sf2_attributes', []);
+        $this->mockRedirectBinding($originalRequest);
+
+        $this->gatewayLoginService->singleSignOn($httpRequest);
+
+        $sessionData = $this->getSessionData('attributes');
+        $this->assertArrayHasKey('surfnet/gateway/requestdisplay_names', $sessionData);
+        $displayNames = $sessionData['surfnet/gateway/requestdisplay_names'];
+        $this->assertCount(2, $displayNames);
+        $this->assertContains(['lang' => 'en', 'value' => 'Online learning'], $displayNames);
+        $this->assertContains(['lang' => 'nl', 'value' => 'Online leren'], $displayNames);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_does_not_store_display_names_when_flag_is_disabled(): void
+    {
+        $httpRequest = new Request([AuthnRequest::PARAMETER_RELAY_STATE => 'relay_state']);
+
+        $originalRequest = '<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    ID="_123456789012345678901234567890123456789012"
+    Version="2.0"
+    IssueInstant="2014-10-22T11:06:59Z"
+    Destination="https://gateway.org/sso"
+    AssertionConsumerServiceURL="https://sp.com/acs"
+    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+  <saml:Issuer>https://sp.com/metadata</saml:Issuer>
+  <samlp:Extensions>
+    <mdui:UIInfo>
+      <mdui:DisplayName xml:lang="en">Online learning</mdui:DisplayName>
+    </mdui:UIInfo>
+  </samlp:Extensions>
+  <samlp:RequestedAuthnContext>
+    <saml:AuthnContextClassRef>http://stepup.example.com/assurance/loa2</saml:AuthnContextClassRef>
+  </samlp:RequestedAuthnContext>
+</samlp:AuthnRequest>';
+
+        $this->mockSessionData('_sf2_attributes', []);
+        $this->mockRedirectBinding($originalRequest);
+
+        // flag is false (default setUp uses initGatewayService without flag=true)
+        $this->gatewayLoginService->singleSignOn($httpRequest);
+
+        $sessionData = $this->getSessionData('attributes');
+        $this->assertArrayNotHasKey('surfnet/gateway/requestdisplay_names', $sessionData);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_should_throw_an_exception_when_an_invalid_loa_is_requested_when_starting_on_login_flow(): void
     {
         $this->expectException(RequesterFailureException::class);
@@ -205,7 +290,7 @@ final class LoginServiceTest extends GatewaySamlTestCase
      * @param int $now
      * @param array $sessionData
      */
-    private function initGatewayService(array $idpConfiguration, array $spConfiguration, array $loaLevels, DateTime $now): void
+    private function initGatewayService(array $idpConfiguration, array $spConfiguration, array $loaLevels, DateTime $now, bool $enableServiceNameFromSamlAuthnRequest = false): void
     {
         $session = new Session($this->sessionStorage);
         $requestStackMock = $this->createMock(RequestStack::class);
@@ -235,7 +320,8 @@ final class LoginServiceTest extends GatewaySamlTestCase
             $this->loaResolutionService,
             $hostedServiceProvider,
             $this->remoteIdp,
-            $this->redirectBinding
+            $this->redirectBinding,
+            new FeatureConfiguration($enableServiceNameFromSamlAuthnRequest)
         );
     }
 

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Resources/config/services.yml
@@ -31,6 +31,7 @@ services:
             - "@surfnet_saml.logger"
             - "@gateway.proxy.response_context"
             - "@second_factor_only.response_context"
+            - "@gateway.feature_configuration"
 
     gssp.service.gssp.consume_assertion:
         class: Surfnet\StepupGateway\SamlStepupProviderBundle\Service\Gateway\ConsumeAssertionService

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/SecondFactorVerificationService.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/SecondFactorVerificationService.php
@@ -93,16 +93,18 @@ class SecondFactorVerificationService
         );
         $authnRequest->setSubject($subjectNameId);
 
-        if ($this->featureConfiguration->isServiceNameFromSamlAuthnRequestEnabled()) {
-            $activeResponseContext = $responseContextServiceId === 'second_factor_only.response_context'
-                ? $this->sfoResponseContext
-                : $this->responseContext;
-            $displayNames = $activeResponseContext->resolveServiceDisplayNames();
-            if (!empty($displayNames)) {
-                $authnRequest->setExtensions(
-                    UiInfoExtensionHelper::buildExtensionsWithUiInfo($displayNames)
-                );
-            }
+        $activeResponseContext = $responseContextServiceId === 'second_factor_only.response_context'
+            ? $this->sfoResponseContext
+            : $this->responseContext;
+        // The middleware service_name override must always be honored. Only the AuthnRequest
+        // mdui:DisplayName-derived fallback is gated behind the feature flag.
+        $displayNames = $activeResponseContext->resolveServiceDisplayNames(
+            $this->featureConfiguration->isServiceNameFromSamlAuthnRequestEnabled()
+        );
+        if (!empty($displayNames)) {
+            $authnRequest->setExtensions(
+                UiInfoExtensionHelper::buildExtensionsWithUiInfo($displayNames)
+            );
         }
 
         $stateHandler

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/SecondFactorVerificationService.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Service/Gateway/SecondFactorVerificationService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2018 SURFnet bv
  *
@@ -20,7 +21,9 @@ namespace Surfnet\StepupGateway\SamlStepupProviderBundle\Service\Gateway;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
+use Surfnet\StepupGateway\GatewayBundle\Configuration\FeatureConfiguration;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
+use Surfnet\StepupGateway\GatewayBundle\Saml\UiInfoExtensionHelper;
 use Surfnet\StepupGateway\SamlStepupProviderBundle\Exception\InvalidSubjectException;
 use Surfnet\StepupGateway\SamlStepupProviderBundle\Provider\Provider;
 
@@ -35,14 +38,12 @@ class SecondFactorVerificationService
     /** @var ResponseContext */
     private $sfoResponseContext;
 
-    /**
-     * SecondFactorVerificationService constructor.
-     * @param SamlAuthenticationLogger $samlLogger
-     * @param ResponseContext $responseContext
-     * @param ResponseContext $sfoResponseContext
-     */
-    public function __construct(SamlAuthenticationLogger $samlLogger, ResponseContext $responseContext, ResponseContext $sfoResponseContext)
-    {
+    public function __construct(
+        SamlAuthenticationLogger $samlLogger,
+        ResponseContext $responseContext,
+        ResponseContext $sfoResponseContext,
+        private readonly FeatureConfiguration $featureConfiguration = new FeatureConfiguration()
+    ) {
         $this->samlLogger = $samlLogger;
         $this->responseContext = $responseContext;
         $this->sfoResponseContext = $sfoResponseContext;
@@ -91,6 +92,18 @@ class SecondFactorVerificationService
             $provider->getRemoteIdentityProvider()
         );
         $authnRequest->setSubject($subjectNameId);
+
+        if ($this->featureConfiguration->isServiceNameFromSamlAuthnRequestEnabled()) {
+            $activeResponseContext = $responseContextServiceId === 'second_factor_only.response_context'
+                ? $this->sfoResponseContext
+                : $this->responseContext;
+            $displayNames = $activeResponseContext->resolveServiceDisplayNames();
+            if (!empty($displayNames)) {
+                $authnRequest->setExtensions(
+                    UiInfoExtensionHelper::buildExtensionsWithUiInfo($displayNames)
+                );
+            }
+        }
 
         $stateHandler
             ->setRequestId($originalRequestId)

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Tests/Service/Gateway/SecondFactorVerificationServiceTest.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Tests/Service/Gateway/SecondFactorVerificationServiceTest.php
@@ -159,6 +159,7 @@ class SecondFactorVerificationServiceTest extends GatewaySamlTestCase
 
         $this->mockSessionData('_sf2_attributes', [
             'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+            'surfnet/gateway/gssp/test_provider/service_provider' => 'https://gateway.tld/authentication/metadata',
         ]);
 
         $authnRequest = $this->samlProxySecondFactorService->sendSecondFactorVerificationAuthnRequest(
@@ -168,6 +169,39 @@ class SecondFactorVerificationServiceTest extends GatewaySamlTestCase
         );
 
         $this->assertEmpty($authnRequest->getExtensions()->getChunks());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_still_sets_ui_info_extension_from_middleware_override_when_feature_flag_disabled(): void
+    {
+        $responseContext = m::mock(ResponseContext::class);
+        $responseContext->shouldReceive('getInResponseTo')->andReturn('_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e');
+        $responseContext->shouldReceive('resolveServiceDisplayNames')
+            ->with(false)
+            ->andReturn([new DisplayName('en', 'Middleware Service Name')]);
+
+        $sfoResponseContext = m::mock(ResponseContext::class);
+        $sfoResponseContext->shouldNotReceive('resolveServiceDisplayNames');
+
+        $samlLogger = new SamlAuthenticationLogger($this->logger);
+        // FeatureConfiguration defaults to disabled (false) here.
+        $service = new SecondFactorVerificationService($samlLogger, $responseContext, $sfoResponseContext);
+
+        $this->mockSessionData('_sf2_attributes', [
+            'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+        ]);
+
+        $authnRequest = $service->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            'test-gssp-id',
+            'service_id'
+        );
+
+        $chunks = $authnRequest->getExtensions()->getChunks();
+        $this->assertArrayHasKey('UIInfo', $chunks);
+        $uiInfo = $chunks['UIInfo']->getValue();
+        $displayName = $uiInfo->childNodes->item(0);
+        $this->assertSame('Middleware Service Name', $displayName->textContent);
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -346,6 +380,16 @@ class SecondFactorVerificationServiceTest extends GatewaySamlTestCase
         $this->idp = new IdentityProvider($idpConfiguration);
         $serviceProvider = new ServiceProvider($spConfiguration);
         $this->samlEntityService = m::mock(SamlEntityService::class);
+        // resolveServiceDisplayNames() is now always invoked (regardless of the feature flag), so it
+        // always resolves a middleware ServiceProvider entity. None of these tests configure a
+        // middleware service_name, so return a plain SP without one (no middleware override present).
+        $this->samlEntityService->shouldReceive('getServiceProvider')->andReturn(
+            new GatewayServiceProvider([
+                'entityId' => 'https://gateway.tld/authentication/metadata',
+                'assertionConsumerUrl' => 'https://gateway.tld/authentication/consume-assertion',
+                'privateKeys' => [],
+            ])
+        );
 
         $this->provider = new Provider(
             'testProvider',

--- a/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Tests/Service/Gateway/SecondFactorVerificationServiceTest.php
+++ b/src/Surfnet/StepupGateway/SamlStepupProviderBundle/Tests/Service/Gateway/SecondFactorVerificationServiceTest.php
@@ -23,6 +23,9 @@ use Surfnet\SamlBundle\Entity\IdentityProvider;
 use Surfnet\SamlBundle\Entity\ServiceProvider;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
+use Surfnet\StepupGateway\GatewayBundle\Configuration\FeatureConfiguration;
+use Surfnet\StepupGateway\GatewayBundle\Entity\ServiceProvider as GatewayServiceProvider;
+use Surfnet\StepupGateway\GatewayBundle\Saml\DisplayName;
 use Surfnet\StepupGateway\GatewayBundle\Saml\ResponseContext;
 use Surfnet\StepupGateway\GatewayBundle\Service\SamlEntityService;
 use Surfnet\StepupGateway\GatewayBundle\Tests\TestCase\GatewaySamlTestCase;
@@ -149,11 +152,186 @@ class SecondFactorVerificationServiceTest extends GatewaySamlTestCase
     }
 
 
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_does_not_set_extensions_when_feature_flag_disabled(): void
+    {
+        $subjectNameId = 'test-gssp-id';
+
+        $this->mockSessionData('_sf2_attributes', [
+            'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+        ]);
+
+        $authnRequest = $this->samlProxySecondFactorService->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            $subjectNameId,
+            'service_id'
+        );
+
+        $this->assertEmpty($authnRequest->getExtensions()->getChunks());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_sets_ui_info_extension_from_stored_display_names_when_flag_enabled(): void
+    {
+        $responseContext = m::mock(ResponseContext::class);
+        $responseContext->shouldReceive('getInResponseTo')->andReturn('_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e');
+        $responseContext->shouldReceive('resolveServiceDisplayNames')->andReturn([
+            new DisplayName('en', 'My Service'),
+            new DisplayName('nl', 'Mijn Dienst'),
+        ]);
+
+        $sfoResponseContext = m::mock(ResponseContext::class);
+        $sfoResponseContext->shouldNotReceive('resolveServiceDisplayNames');
+
+        $samlLogger = new SamlAuthenticationLogger($this->logger);
+        $service = new SecondFactorVerificationService($samlLogger, $responseContext, $sfoResponseContext, new FeatureConfiguration(true));
+
+        $this->mockSessionData('_sf2_attributes', [
+            'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+        ]);
+
+        $authnRequest = $service->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            'test-gssp-id',
+            'service_id'
+        );
+
+        $chunks = $authnRequest->getExtensions()->getChunks();
+        $this->assertArrayHasKey('UIInfo', $chunks);
+        $uiInfo = $chunks['UIInfo']->getValue();
+        $this->assertSame('UIInfo', $uiInfo->localName);
+        $this->assertSame(2, $uiInfo->childNodes->length);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_prefers_middleware_service_name_over_stored_display_names(): void
+    {
+        $responseContext = m::mock(ResponseContext::class);
+        $responseContext->shouldReceive('getInResponseTo')->andReturn('_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e');
+        $responseContext->shouldReceive('resolveServiceDisplayNames')->andReturn([
+            new DisplayName('en', 'Middleware Service'),
+        ]);
+
+        $sfoResponseContext = m::mock(ResponseContext::class);
+        $sfoResponseContext->shouldNotReceive('resolveServiceDisplayNames');
+
+        $samlLogger = new SamlAuthenticationLogger($this->logger);
+        $service = new SecondFactorVerificationService($samlLogger, $responseContext, $sfoResponseContext, new FeatureConfiguration(true));
+
+        $this->mockSessionData('_sf2_attributes', [
+            'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+        ]);
+
+        $authnRequest = $service->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            'test-gssp-id',
+            'service_id'
+        );
+
+        $chunks = $authnRequest->getExtensions()->getChunks();
+        $this->assertArrayHasKey('UIInfo', $chunks);
+        $uiInfo = $chunks['UIInfo']->getValue();
+        $displayName = $uiInfo->childNodes->item(0);
+        $this->assertSame('Middleware Service', $displayName->textContent);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_sets_no_extensions_when_flag_enabled_but_no_display_names_available(): void
+    {
+        $responseContext = m::mock(ResponseContext::class);
+        $responseContext->shouldReceive('getInResponseTo')->andReturn('_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e');
+        $responseContext->shouldReceive('resolveServiceDisplayNames')->andReturn([]);
+
+        $sfoResponseContext = m::mock(ResponseContext::class);
+        $sfoResponseContext->shouldNotReceive('resolveServiceDisplayNames');
+
+        $samlLogger = new SamlAuthenticationLogger($this->logger);
+        $service = new SecondFactorVerificationService($samlLogger, $responseContext, $sfoResponseContext, new FeatureConfiguration(true));
+
+        $this->mockSessionData('_sf2_attributes', [
+            'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+        ]);
+
+        $authnRequest = $service->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            'test-gssp-id',
+            'service_id'
+        );
+
+        $this->assertEmpty($authnRequest->getExtensions()->getChunks());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_sets_ui_info_from_middleware_service_name_when_no_authn_request_display_names(): void
+    {
+        $responseContext = m::mock(ResponseContext::class);
+        $responseContext->shouldReceive('getInResponseTo')->andReturn('_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e');
+        $responseContext->shouldReceive('resolveServiceDisplayNames')->andReturn([
+            new DisplayName('en', 'Middleware Only Service'),
+        ]);
+
+        $sfoResponseContext = m::mock(ResponseContext::class);
+        $sfoResponseContext->shouldNotReceive('resolveServiceDisplayNames');
+
+        $samlLogger = new SamlAuthenticationLogger($this->logger);
+        $service = new SecondFactorVerificationService($samlLogger, $responseContext, $sfoResponseContext, new FeatureConfiguration(true));
+
+        $this->mockSessionData('_sf2_attributes', [
+            'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+        ]);
+
+        $authnRequest = $service->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            'test-gssp-id',
+            'service_id'
+        );
+
+        $chunks = $authnRequest->getExtensions()->getChunks();
+        $this->assertArrayHasKey('UIInfo', $chunks);
+        $uiInfo = $chunks['UIInfo']->getValue();
+        $this->assertSame(1, $uiInfo->childNodes->length);
+        $displayName = $uiInfo->childNodes->item(0);
+        $this->assertSame('Middleware Only Service', $displayName->textContent);
+        $this->assertSame('en', $displayName->getAttribute('xml:lang'));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_uses_sfo_response_context_when_response_context_service_id_is_sfo(): void
+    {
+        $ssoResponseContext = m::mock(ResponseContext::class);
+        $ssoResponseContext->shouldNotReceive('resolveServiceDisplayNames');
+        $ssoResponseContext->shouldNotReceive('getInResponseTo');
+
+        $sfoResponseContext = m::mock(ResponseContext::class);
+        $sfoResponseContext->shouldReceive('getInResponseTo')->andReturn('_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e');
+        $sfoResponseContext->shouldReceive('resolveServiceDisplayNames')->andReturn([
+            new DisplayName('en', 'SFO Service'),
+        ]);
+
+        $samlLogger = new SamlAuthenticationLogger($this->logger);
+        $service = new SecondFactorVerificationService($samlLogger, $ssoResponseContext, $sfoResponseContext, new FeatureConfiguration(true));
+
+        $this->mockSessionData('_sf2_attributes', [
+            'surfnet/gateway/gssp/test_provider/request_id' => '_1b8f282a9c194b264ef68761171539380de78b45038f65b8609df868f55e',
+        ]);
+
+        $authnRequest = $service->sendSecondFactorVerificationAuthnRequest(
+            $this->provider,
+            'test-gssp-id',
+            'second_factor_only.response_context'
+        );
+
+        $chunks = $authnRequest->getExtensions()->getChunks();
+        $this->assertArrayHasKey('UIInfo', $chunks);
+        $uiInfo = $chunks['UIInfo']->getValue();
+        $displayName = $uiInfo->childNodes->item(0);
+        $this->assertSame('SFO Service', $displayName->textContent);
+    }
+
     /**
      * @param array $remoteIdpConfiguration
      * @param array $idpConfiguration
      * @param array $spConfiguration
-     * @param array $connectedServiceProviders
      * @param DateTime $now
      */
     private function initSamlProxyService(array $remoteIdpConfiguration, array $idpConfiguration, array $spConfiguration, DateTime $now): void

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Resources/config/services.yml
@@ -147,6 +147,7 @@ services:
             - "@second_factor_only.http.binding_factory"
             - "@second_factor_only.validate_nameid"
             - "@second_factor_only.loa_resolution"
+            - "@gateway.feature_configuration"
 
     second_factor_only.respond_service:
         class: Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\Gateway\RespondService

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/LoginService.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Service/Gateway/LoginService.php
@@ -23,8 +23,10 @@ use Surfnet\SamlBundle\Http\HttpBindingFactory;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 use Surfnet\SamlBundle\SAML2\AuthnRequest;
 use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
+use Surfnet\StepupGateway\GatewayBundle\Configuration\FeatureConfiguration;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RequesterFailureException;
 use Surfnet\StepupGateway\GatewayBundle\Saml\Proxy\ProxyStateHandler;
+use Surfnet\StepupGateway\GatewayBundle\Saml\UiInfoExtensionHelper;
 use Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\LoaResolutionService;
 use Surfnet\StepupGateway\SecondFactorOnlyBundle\Service\SecondFactorOnlyNameIdValidationService;
 use Symfony\Component\HttpFoundation\Request;
@@ -64,7 +66,8 @@ class LoginService
         ProxyStateHandler $stateHandler,
         HttpBindingFactory $httpBindingFactory,
         SecondFactorOnlyNameIdValidationService $secondFactorOnlyNameValidatorService,
-        LoaResolutionService $loaResolutionService
+        LoaResolutionService $loaResolutionService,
+        private readonly FeatureConfiguration $featureConfiguration = new FeatureConfiguration()
     ) {
         $this->logger = $logger;
         $this->samlLogger = $samlLogger;
@@ -131,6 +134,10 @@ class LoginService
             ->setResponseContextServiceId('second_factor_only.response_context');
 
         $this->stateHandler->markAuthenticationModeForRequest($originalRequestId, 'sfo');
+
+        if ($this->featureConfiguration->isServiceNameFromSamlAuthnRequestEnabled()) {
+            UiInfoExtensionHelper::parseAndStore($originalRequest, $this->stateHandler);
+        }
 
         // Check if the NameID is provided and we may use it.
         $nameId = $originalRequest->getNameId();

--- a/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Tests/Service/Gateway/LoginServiceTest.php
+++ b/src/Surfnet/StepupGateway/SecondFactorOnlyBundle/Tests/Service/Gateway/LoginServiceTest.php
@@ -26,6 +26,8 @@ use Surfnet\SamlBundle\Http\PostBinding;
 use Surfnet\SamlBundle\Http\RedirectBinding;
 use Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger;
 use Surfnet\SamlBundle\SAML2\ReceivedAuthnRequest;
+use Surfnet\StepupGateway\GatewayBundle\Configuration\FeatureConfiguration;
+use Surfnet\StepupGateway\GatewayBundle\Saml\UiInfoExtensionHelper;
 use Surfnet\StepupBundle\Service\LoaResolutionService;
 use Surfnet\StepupBundle\Value\Loa;
 use Surfnet\StepupGateway\GatewayBundle\Exception\RequesterFailureException;
@@ -236,6 +238,126 @@ final class LoginServiceTest extends GatewaySamlTestCase
         $this->gatewayLoginService->singleSignOn($httpRequest, $originalRequest);
     }
 
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_stores_display_names_from_ui_info_when_sfo_flag_is_enabled(): void
+    {
+        $loaLevels = [
+            [1, 'http://stepup.example.com/assurance/loa1'],
+            [2, 'http://stepup.example.com/assurance/loa2'],
+            [3, 'http://stepup.example.com/assurance/loa3'],
+        ];
+        $loaAliases = [
+            'http://stepup.example.com/assurance/loa2' => 'http://suaas.example.com/assurance/loa2',
+        ];
+        $this->initGatewayLoginService($loaLevels, $loaAliases, true);
+
+        $httpRequest = new Request();
+        $originalRequest = ReceivedAuthnRequest::from('<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                    ID="_uiinfo_sfo_enabled"
+                    Version="2.0"
+                    IssueInstant="2017-04-18T16:35:32Z"
+                    Destination="https://tiqr.tld/saml/sso"
+                    AssertionConsumerServiceURL="https://gateway.tld/gssp/tiqr/consume-assertion"
+                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+    <saml:Issuer>https://gateway.tld/gssp/tiqr/metadata</saml:Issuer>
+    <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">oom60v-3art</saml:NameID>
+    </saml:Subject>
+    <samlp:Extensions>
+        <mdui:UIInfo>
+            <mdui:DisplayName xml:lang="en">My SFO Service</mdui:DisplayName>
+        </mdui:UIInfo>
+    </samlp:Extensions>
+    <samlp:Scoping ProxyCount="10">
+        <samlp:RequesterID>https://ra.tld/vetting-procedure/gssf/tiqr/metadata</samlp:RequesterID>
+    </samlp:Scoping>
+    <samlp:RequestedAuthnContext>
+        <saml:AuthnContextClassRef>http://suaas.example.com/assurance/loa2</saml:AuthnContextClassRef>
+    </samlp:RequestedAuthnContext>
+</samlp:AuthnRequest>');
+
+        $this->mockSessionData('_sf2_attributes', []);
+
+        $serviceProvider = Mockery::mock(ServiceProvider::class)
+            ->shouldReceive('isAllowedToUseSecondFactorOnlyFor')
+            ->with('oom60v-3art')
+            ->andReturn(true)
+            ->getMock();
+
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('https://gateway.tld/gssp/tiqr/metadata')
+            ->andReturn($serviceProvider);
+
+        $this->gatewayLoginService->singleSignOn($httpRequest, $originalRequest);
+
+        $sessionData = $this->getSessionData('attributes');
+        $this->assertArrayHasKey('surfnet/gateway/requestdisplay_names', $sessionData);
+        $this->assertSame(
+            [['lang' => 'en', 'value' => 'My SFO Service']],
+            $sessionData['surfnet/gateway/requestdisplay_names']
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_does_not_store_display_names_when_sfo_flag_is_disabled(): void
+    {
+        $loaLevels = [
+            [1, 'http://stepup.example.com/assurance/loa1'],
+            [2, 'http://stepup.example.com/assurance/loa2'],
+            [3, 'http://stepup.example.com/assurance/loa3'],
+        ];
+        $loaAliases = [
+            'http://stepup.example.com/assurance/loa2' => 'http://suaas.example.com/assurance/loa2',
+        ];
+        $this->initGatewayLoginService($loaLevels, $loaAliases, false);
+
+        $httpRequest = new Request();
+        $originalRequest = ReceivedAuthnRequest::from('<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                    ID="_uiinfo_sfo_disabled"
+                    Version="2.0"
+                    IssueInstant="2017-04-18T16:35:32Z"
+                    Destination="https://tiqr.tld/saml/sso"
+                    AssertionConsumerServiceURL="https://gateway.tld/gssp/tiqr/consume-assertion"
+                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+    <saml:Issuer>https://gateway.tld/gssp/tiqr/metadata</saml:Issuer>
+    <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">oom60v-3art</saml:NameID>
+    </saml:Subject>
+    <samlp:Extensions>
+        <mdui:UIInfo>
+            <mdui:DisplayName xml:lang="en">My SFO Service</mdui:DisplayName>
+        </mdui:UIInfo>
+    </samlp:Extensions>
+    <samlp:Scoping ProxyCount="10">
+        <samlp:RequesterID>https://ra.tld/vetting-procedure/gssf/tiqr/metadata</samlp:RequesterID>
+    </samlp:Scoping>
+    <samlp:RequestedAuthnContext>
+        <saml:AuthnContextClassRef>http://suaas.example.com/assurance/loa2</saml:AuthnContextClassRef>
+    </samlp:RequestedAuthnContext>
+</samlp:AuthnRequest>');
+
+        $this->mockSessionData('_sf2_attributes', []);
+
+        $serviceProvider = Mockery::mock(ServiceProvider::class)
+            ->shouldReceive('isAllowedToUseSecondFactorOnlyFor')
+            ->with('oom60v-3art')
+            ->andReturn(true)
+            ->getMock();
+
+        $this->samlEntityService->shouldReceive('getServiceProvider')
+            ->with('https://gateway.tld/gssp/tiqr/metadata')
+            ->andReturn($serviceProvider);
+
+        $this->gatewayLoginService->singleSignOn($httpRequest, $originalRequest);
+
+        $sessionData = $this->getSessionData('attributes');
+        $this->assertArrayNotHasKey('surfnet/gateway/requestdisplay_names', $sessionData);
+    }
+
     /**
      * @param array $idpConfiguration
      * @param array $loaAliases
@@ -243,7 +365,7 @@ final class LoginServiceTest extends GatewaySamlTestCase
      * @param DateTime $now
      * @param array $sessionData
      */
-    private function initGatewayLoginService(array $loaLevels,  array $loaAliases): void
+    private function initGatewayLoginService(array $loaLevels, array $loaAliases, bool $enableServiceNameFromSamlAuthnRequest = false): void
     {
         $session = new Session($this->sessionStorage);
         $requestStackMock = $this->createMock(RequestStack::class);
@@ -268,7 +390,8 @@ final class LoginServiceTest extends GatewaySamlTestCase
             $this->stateHandler,
             $httpBindingFactory,
             $secondFactorOnlyNameValidatorService,
-            $loaResolutionService
+            $loaResolutionService,
+            new FeatureConfiguration($enableServiceNameFromSamlAuthnRequest)
         );
     }
 


### PR DESCRIPTION
## Problem

With the AuthnRequest-service-name feature flag disabled, the middleware-configured `service_name` override for a service provider was not shown during second factor verification either, even though the flag is only meant to control the AuthnRequest mdui:DisplayName fallback.

## Root cause

`SecondFactorVerificationService::sendSecondFactorVerificationAuthnRequest()` wrapped the entire `resolveServiceDisplayNames()` call (both the middleware-override branch and the AuthnRequest-fallback branch) in the `isServiceNameFromSamlAuthnRequestEnabled()` flag check, instead of only gating the AuthnRequest-derived fallback.

## Fix

`ResponseContext::resolveServiceDisplayNames()` now accepts an `includeAuthnRequestFallback` parameter. The middleware override is always considered; only the AuthnRequest fallback is skipped when the parameter is false. `SecondFactorVerificationService` now always calls `resolveServiceDisplayNames()`, passing the feature flag value as this parameter instead of wrapping the whole call.

## Testing

Added tests confirming the middleware override survives with the flag disabled, and that no fallback occurs without it. Verified against the old code that these tests fail (confirming they reproduce the bug). Full suite (265/265), phpcs and phpmd pass.